### PR TITLE
Fix bug where destroy link on apps index did not work

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require jquery
+//= require jquery_ujs
+//= require turbolinks
+//= require_tree .

--- a/app/assets/javascripts/apps.js
+++ b/app/assets/javascripts/apps.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/sessions.js
+++ b/app/assets/javascripts/sessions.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/visits.js
+++ b/app/assets/javascripts/visits.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,0 +1,15 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any styles
+ * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
+ * file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ */

--- a/app/assets/stylesheets/apps.css
+++ b/app/assets/stylesheets/apps.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/assets/stylesheets/sessions.css
+++ b/app/assets/stylesheets/sessions.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/assets/stylesheets/visits.css
+++ b/app/assets/stylesheets/visits.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/


### PR DESCRIPTION
Got too trigger happy a few commits ago where I nuked app/assets/javascripts and app/assets/stylesheets and the destroy link stopped working. Oops.
